### PR TITLE
Bump Go version to 1.23.10 due to CVE fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/upbound/provider-aws
 
-go 1.23.8
+go 1.23.10
 
 require (
 	dario.cat/mergo v1.0.1


### PR DESCRIPTION
This PR bumps the Go version due to security fix: